### PR TITLE
Added delete button to delete entire file - all versions together

### DIFF
--- a/app/models/file.py
+++ b/app/models/file.py
@@ -554,4 +554,57 @@ class File:
             return True
             
         except Exception as e:
-            raise Exception(f"Failed to delete file: {str(e)}") 
+            raise Exception(f"Failed to delete file: {str(e)}")
+
+    @staticmethod
+    def delete_all_versions(customer_id, machine_id, filename):
+        """Delete all versions of a file from a machine"""
+        try:
+            db = get_database()
+            if db is None:
+                raise Exception("MongoDB connection not available")
+
+            customer = db.customers.find_one({'customer_id': customer_id})
+            if not customer or 'machines' not in customer:
+                raise Exception("Customer or machine not found")
+
+            machine = next(
+                (m for m in customer['machines'] if m['id'] == machine_id),
+                None
+            )
+            if not machine or 'files' not in machine:
+                raise Exception("Machine not found or has no files")
+
+            file_versions = [f for f in machine['files'] if f['filename'] == filename]
+            if not file_versions:
+                raise Exception("File not found")
+
+            # Delete all Azure blobs for this filename
+            for file_data in file_versions:
+                if file_data.get('storage_type') == 'azure' and 'blob_name' in file_data:
+                    try:
+                        if Config.AZURE_STORAGE_CONNECTION_STRING and Config.AZURE_STORAGE_CONTAINER_NAME:
+                            blob_service_client = BlobServiceClient.from_connection_string(
+                                Config.AZURE_STORAGE_CONNECTION_STRING
+                            )
+                            container_client = blob_service_client.get_container_client(
+                                Config.AZURE_STORAGE_CONTAINER_NAME
+                            )
+                            blob_client = container_client.get_blob_client(file_data['blob_name'])
+                            blob_client.delete_blob()
+                    except Exception as azure_error:
+                        print(f"Warning: Failed to delete blob from Azure: {azure_error}")
+
+            # Pull all entries matching this filename in one operation
+            result = db.customers.update_one(
+                {'customer_id': customer_id, 'machines.id': machine_id},
+                {'$pull': {'machines.$.files': {'filename': filename}}}
+            )
+
+            if result.modified_count == 0:
+                raise Exception("File not found")
+
+            return True
+
+        except Exception as e:
+            raise Exception(f"Failed to delete all versions: {str(e)}")

--- a/app/routes/file_routes.py
+++ b/app/routes/file_routes.py
@@ -366,6 +366,38 @@ async def admin_delete_file(
     try:
         FileModel.delete_file(customer_id, machine_id, filename, version)
         return {'message': 'File deleted successfully'}
-        
+
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@file_bp.delete('/delete/{customer_id}/{machine_id}/{filename}')
+async def delete_all_file_versions(
+    customer_id: str,
+    machine_id: str,
+    filename: str,
+    current_user=Depends(customer_required)
+):
+    """Delete all versions of a file"""
+    try:
+        if current_user.customer_id != customer_id:
+            raise HTTPException(status_code=403, detail='Unauthorized')
+        FileModel.delete_all_versions(customer_id, machine_id, filename)
+        return {'message': 'All versions deleted successfully'}
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@file_bp.delete('/admin/delete/{customer_id}/{machine_id}/{filename}')
+async def admin_delete_all_file_versions(
+    customer_id: str,
+    machine_id: str,
+    filename: str,
+    current_user=Depends(admin_required)
+):
+    """Admin: Delete all versions of a file"""
+    try:
+        FileModel.delete_all_versions(customer_id, machine_id, filename)
+        return {'message': 'All versions deleted successfully'}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/frontend/src/components/AdminDashboard.js
+++ b/frontend/src/components/AdminDashboard.js
@@ -284,16 +284,33 @@ const AdminDashboard = () => {
       await axios.delete(
         `/api/files/admin/delete/${selectedCustomer.customer_id}/${selectedMachine.id}/${filename}/${version}`
       );
-      
-      setSelectedFileVersions(prevVersions => 
-        
+      setSelectedFileVersions(prevVersions =>
         prevVersions.filter(v => v.version !== version)
       );
       setSuccess("File deleted successfully");
-      console.log("Hello");
       fetchMachineFiles(selectedCustomer.customer_id, selectedMachine.id);
     } catch (error) {
-      setError("Failed to delete file");
+      setError(error.response?.data?.detail || "Failed to delete file");
+    }
+  };
+
+  const handleDeleteAllVersions = async (filename, totalVersions) => {
+    if (
+      !window.confirm(
+        `Are you sure you want to delete ALL ${totalVersions} version(s) of "${filename}"? This cannot be undone.`
+      )
+    ) {
+      return;
+    }
+
+    try {
+      await axios.delete(
+        `/api/files/admin/delete/${selectedCustomer.customer_id}/${selectedMachine.id}/${filename}`
+      );
+      setSuccess(`All versions of "${filename}" deleted successfully`);
+      fetchMachineFiles(selectedCustomer.customer_id, selectedMachine.id);
+    } catch (error) {
+      setError(error.response?.data?.detail || "Failed to delete file");
     }
   };
 
@@ -574,6 +591,19 @@ const AdminDashboard = () => {
                                     >
                                       <Eye className="me-1" />
                                       Versions
+                                    </Button>
+                                    <Button
+                                      variant="outline-danger"
+                                      size="sm"
+                                      onClick={() =>
+                                        handleDeleteAllVersions(
+                                          file.filename,
+                                          file.total_versions
+                                        )
+                                      }
+                                    >
+                                      <Trash className="me-1" />
+                                      Delete File
                                     </Button>
                                   </td>
                                 </tr>

--- a/frontend/src/components/CustomerDashboard.js
+++ b/frontend/src/components/CustomerDashboard.js
@@ -287,19 +287,33 @@ const CustomerDashboard = () => {
       await axios.delete(
         `/api/files/delete/${user.customer_id}/${selectedMachine.id}/${filename}/${version}`
       );
-      
-      // Immediately update the modal's version list
-      const updatedVersions = selectedFileVersions.filter(
-        v => String(v.version) !== String(version)
+      setSelectedFileVersions(prevVersions =>
+        prevVersions.filter(v => String(v.version) !== String(version))
       );
-      setSelectedFileVersions(updatedVersions);
-      
       setSuccess("File deleted successfully");
-      
-      // Refresh the main files list
       fetchMachineFiles(selectedMachine.id);
     } catch (error) {
-      setError("Failed to delete file");
+      setError(error.response?.data?.detail || "Failed to delete file");
+    }
+  };
+
+  const handleDeleteAllVersions = async (filename, totalVersions) => {
+    if (
+      !window.confirm(
+        `Are you sure you want to delete ALL ${totalVersions} version(s) of "${filename}"? This cannot be undone.`
+      )
+    ) {
+      return;
+    }
+
+    try {
+      await axios.delete(
+        `/api/files/delete/${user.customer_id}/${selectedMachine.id}/${filename}`
+      );
+      setSuccess(`All versions of "${filename}" deleted successfully`);
+      fetchMachineFiles(selectedMachine.id);
+    } catch (error) {
+      setError(error.response?.data?.detail || "Failed to delete file");
     }
   };
 
@@ -519,6 +533,19 @@ const CustomerDashboard = () => {
                                     >
                                       <Eye className="me-1" />
                                       Versions
+                                    </Button>
+                                    <Button
+                                      variant="outline-danger"
+                                      size="sm"
+                                      onClick={() =>
+                                        handleDeleteAllVersions(
+                                          file.filename,
+                                          file.total_versions
+                                        )
+                                      }
+                                    >
+                                      <Trash className="me-1" />
+                                      Delete File
                                     </Button>
                                   </td>
                                 </tr>

--- a/test/test_delete_all_versions.py
+++ b/test/test_delete_all_versions.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""
+Tests for the delete-all-versions feature (feature/delete-entire-file).
+
+Covers:
+  1. Customer can delete all versions of their own file
+  2. Customer cannot delete another customer's file (403)
+  3. Deleting a filename that doesn't exist returns an error
+  4. Admin can delete any customer's file
+  5. Unauthenticated request is rejected
+
+Run with: python test/test_delete_all_versions.py
+Backend must be running at http://localhost:8000
+"""
+
+import requests
+import time
+import os
+
+BASE_URL = "http://localhost:8000"
+
+# Unique emails per run so tests don't collide with previous runs
+_ts = int(time.time())
+_machine_counter = 0
+CUSTOMER_A_EMAIL = f"delete_test_a_{_ts}@example.com"
+CUSTOMER_B_EMAIL = f"delete_test_b_{_ts}@example.com"
+PASSWORD = "password123"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _register_and_login(email):
+    """Register a new customer and return their token + customer_id."""
+    requests.post(f"{BASE_URL}/api/customers/register", json={
+        "email": email, "password": PASSWORD,
+        "name": "Test User", "phone": "0000000000", "address": "Test St"
+    })
+    resp = requests.post(f"{BASE_URL}/api/customers/login",
+                         json={"email": email, "password": PASSWORD})
+    data = resp.json()
+    return data["token"], data["customer_id"]
+
+
+def _admin_token():
+    resp = requests.post(f"{BASE_URL}/api/customers/admin/login",
+                         json={"email": "admin@example.com", "password": "admin123"})
+    return resp.json()["token"]
+
+
+def _create_machine(token, customer_id):
+    global _machine_counter
+    _machine_counter += 1
+    resp = requests.post(
+        f"{BASE_URL}/api/machines/customer/{customer_id}",
+        json={
+            "name": "Test Machine",
+            "mac_address": f"AA:BB:CC:{_ts % 99:02X}:{_machine_counter:02X}:FF",
+            "description": "test",
+            "customer_id": customer_id
+        },
+        headers={"Authorization": f"Bearer {token}"}
+    )
+    return resp.json()["id"]
+
+
+def _upload_file(token, customer_id, machine_id, filename, version):
+    """Upload a small text file."""
+    tmp = f"/tmp/{filename}"
+    with open(tmp, "w") as f:
+        f.write(f"test content v{version}")
+    with open(tmp, "rb") as f:
+        resp = requests.post(
+            f"{BASE_URL}/api/files/customer/{customer_id}/machine/{machine_id}/upload",
+            files={"file": (filename, f, "text/plain")},
+            data={"version": version},
+            headers={"Authorization": f"Bearer {token}"}
+        )
+    os.remove(tmp)
+    return resp
+
+
+def _versions_of(token, customer_id, machine_id, filename):
+    """Return all stored versions of a filename using the dedicated versions endpoint."""
+    resp = requests.get(
+        f"{BASE_URL}/api/files/versions/{customer_id}/{machine_id}/{filename}",
+        headers={"Authorization": f"Bearer {token}"}
+    )
+    return resp.json().get("versions", [])
+
+
+def ok(msg):   print(f"  PASS  {msg}")
+def fail(msg): print(f"  FAIL  {msg}")
+
+
+# ---------------------------------------------------------------------------
+# Setup — runs once, creates throwaway data for all tests
+# ---------------------------------------------------------------------------
+
+print("\nSetting up test data...")
+token_a, cid_a = _register_and_login(CUSTOMER_A_EMAIL)
+token_b, cid_b = _register_and_login(CUSTOMER_B_EMAIL)
+admin_tok       = _admin_token()
+mid_a           = _create_machine(token_a, cid_a)
+
+# Upload two versions of the same filename so we can confirm both get deleted
+_upload_file(token_a, cid_a, mid_a, "firmware.bin", "1.0")
+_upload_file(token_a, cid_a, mid_a, "firmware.bin", "1.1")
+print("  Setup complete\n")
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — customer deletes all versions of their own file (happy path)
+# ---------------------------------------------------------------------------
+print("Test 1: Customer deletes all versions of their own file")
+
+before = _versions_of(token_a, cid_a, mid_a, "firmware.bin")
+if len(before) < 2:
+    fail(f"Expected 2 versions before delete, got {len(before)} — check upload step")
+else:
+    resp = requests.delete(
+        f"{BASE_URL}/api/files/delete/{cid_a}/{mid_a}/firmware.bin",
+        headers={"Authorization": f"Bearer {token_a}"}
+    )
+    after = _versions_of(token_a, cid_a, mid_a, "firmware.bin")
+    if resp.status_code == 200 and len(after) == 0:
+        ok(f"Deleted {len(before)} versions, 0 remain (status {resp.status_code})")
+    else:
+        fail(f"status={resp.status_code}, versions remaining={len(after)}, body={resp.text}")
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — customer cannot delete another customer's file (expects 403)
+# ---------------------------------------------------------------------------
+print("\nTest 2: Customer cannot delete another customer's file")
+
+# Give customer A a fresh machine + file for this test
+mid_a2 = _create_machine(token_a, cid_a)
+_upload_file(token_a, cid_a, mid_a2, "other.bin", "1.0")
+
+resp = requests.delete(
+    f"{BASE_URL}/api/files/delete/{cid_a}/{mid_a2}/other.bin",
+    headers={"Authorization": f"Bearer {token_b}"}  # Customer B's token — should be blocked
+)
+if resp.status_code == 403:
+    ok(f"Got 403 as expected")
+else:
+    fail(f"Expected 403, got {resp.status_code}: {resp.text}")
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — deleting a filename that does not exist returns an error
+# ---------------------------------------------------------------------------
+print("\nTest 3: Deleting a non-existent filename returns an error")
+
+resp = requests.delete(
+    f"{BASE_URL}/api/files/delete/{cid_a}/{mid_a}/does_not_exist.bin",
+    headers={"Authorization": f"Bearer {token_a}"}
+)
+if resp.status_code >= 400:
+    ok(f"Got error status {resp.status_code} as expected")
+else:
+    fail(f"Expected an error status, got {resp.status_code}: {resp.text}")
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — admin can delete any customer's file
+# ---------------------------------------------------------------------------
+print("\nTest 4: Admin can delete any customer's file")
+
+mid_admin_test = _create_machine(token_a, cid_a)
+_upload_file(token_a, cid_a, mid_admin_test, "admin_target.bin", "1.0")
+
+resp = requests.delete(
+    f"{BASE_URL}/api/files/admin/delete/{cid_a}/{mid_admin_test}/admin_target.bin",
+    headers={"Authorization": f"Bearer {admin_tok}"}
+)
+after = _versions_of(token_a, cid_a, mid_admin_test, "admin_target.bin")
+if resp.status_code == 200 and len(after) == 0:
+    ok(f"Admin deleted file successfully (status {resp.status_code})")
+else:
+    fail(f"status={resp.status_code}, versions remaining={len(after)}, body={resp.text}")
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — unauthenticated request is rejected
+# ---------------------------------------------------------------------------
+print("\nTest 5: Unauthenticated request is rejected")
+
+resp = requests.delete(
+    f"{BASE_URL}/api/files/delete/{cid_a}/{mid_a}/firmware.bin"
+    # no Authorization header
+)
+if resp.status_code in (401, 403):
+    ok(f"Got {resp.status_code} as expected")
+else:
+    fail(f"Expected 401 or 403, got {resp.status_code}: {resp.text}")
+
+
+print("\nDone.")


### PR DESCRIPTION
Added a delete button to delete the entire file - all versions together.
For both customer and admin. 
For deleting a version, the api call has the version number as a parameter
So the new api is created in such a way which gets called, if no version is provided and delete entire file - all versions.